### PR TITLE
화폐 정산 Logic 변경 (RoundState 클래스 추가)

### DIFF
--- a/src/CtrlS/CurrencyManager.java
+++ b/src/CtrlS/CurrencyManager.java
@@ -59,51 +59,6 @@ public final class CurrencyManager {
             return false;
         }
     }
-    // Team-Ctrl-S(Currency)
-    public int calculateCurrency(GameState prevState, GameState currState) {
-        // Score gained this round
-        int scoreDiff = currState.getScore() - prevState.getScore();
-
-        // hitRate of this round
-        int bulletsShotDiff = currState.getBulletsShot() - prevState.getBulletsShot();
-        int shipsDestroyedDiff = currState.getShipsDestroyed() - prevState.getShipsDestroyed();
-        float hitRate = bulletsShotDiff / (float) shipsDestroyedDiff;
-
-        int baseCurrency = scoreDiff / 10;
-        int levelBonus = baseCurrency * currState.getLevel();
-        int currency = baseCurrency + levelBonus;
-
-        if (hitRate > 0.9) {
-            currency += (int) (currency * 0.3); // 30% 보너스 지급
-            Core.getLogger().info("hitRate bonus occurs (30%).");
-        } else if (hitRate > 0.8) {
-            currency += (int) (currency * 0.2); // 20% 보너스 지급
-            Core.getLogger().info("hitRate bonus occurs (20%).");
-        }
-
-        // Round clear time in seconds
-        // DEBUGGING NEEDED(playTime)
-        long timeDifferenceInSeconds = (currState.getTime() - prevState.getTime()) / 1000;
-
-        int timeBonus = 0;
-
-        /*
-          clear time   : 0 ~ 50    : +50
-                       : 51 ~ 80   : +30
-                       : 81 ~ 100  : +10
-                       : 101 ~     : 0
-         */
-        if (timeDifferenceInSeconds <= 50) {
-            timeBonus = 50;
-        } else if (timeDifferenceInSeconds <= 80) {
-            timeBonus = 30;
-        } else if (timeDifferenceInSeconds <= 100) {
-            timeBonus = 10;
-        }
-        currency += timeBonus;
-
-        return currency;
-    }
 
     public int getCurrency() throws IOException {
         return fileManager.loadCurrency();

--- a/src/CtrlS/CurrencyManager.java
+++ b/src/CtrlS/CurrencyManager.java
@@ -2,6 +2,7 @@ package CtrlS;
 
 import engine.Core;
 import engine.FileManager;
+import engine.GameState;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -58,14 +59,19 @@ public final class CurrencyManager {
             return false;
         }
     }
-    // Written by Ctrl+S
-    public int calculateCurrency(int score, int level, float hitRate, long
-            startTime, long endTime) {
-        //
-        int baseCurrency = score / 10;
-        int levelBonus = baseCurrency * level;
+    // Team-Ctrl-S(Currency)
+    public int calculateCurrency(GameState prevState, GameState currState) {
+        // Score gained this round
+        int scoreDiff = currState.getScore() - prevState.getScore();
+
+        // hitRate of this round
+        int bulletsShotDiff = currState.getBulletsShot() - prevState.getBulletsShot();
+        int shipsDestroyedDiff = currState.getShipsDestroyed() - prevState.getShipsDestroyed();
+        float hitRate = bulletsShotDiff / (float) shipsDestroyedDiff;
+
+        int baseCurrency = scoreDiff / 10;
+        int levelBonus = baseCurrency * currState.getLevel();
         int currency = baseCurrency + levelBonus;
-        //
 
         if (hitRate > 0.9) {
             currency += (int) (currency * 0.3); // 30% 보너스 지급
@@ -76,7 +82,9 @@ public final class CurrencyManager {
         }
 
         // Round clear time in seconds
-        long timeDifferenceInSeconds = (endTime - startTime) / 1000;
+        // DEBUGGING NEEDED(playTime)
+        long timeDifferenceInSeconds = (currState.getTime() - prevState.getTime()) / 1000;
+
         int timeBonus = 0;
 
         /*
@@ -96,7 +104,6 @@ public final class CurrencyManager {
 
         return currency;
     }
-
 
     public int getCurrency() throws IOException {
         return fileManager.loadCurrency();

--- a/src/CtrlS/RoundState.java
+++ b/src/CtrlS/RoundState.java
@@ -1,0 +1,36 @@
+package CtrlS;
+
+import engine.GameState;
+
+public class RoundState {
+    private final GameState prevState;
+    private final GameState currState;
+    private final int roundScore;
+    private final int roundBulletsShot;
+    private final int roundShipsDestroyed;
+    private final float roundHitRate;
+    private final long roundTime;
+
+    public RoundState(GameState prevState, GameState currState) {
+        this.prevState = prevState;
+        this.currState = currState;
+        this.roundScore = currState.getScore() - prevState.getScore();
+        this.roundBulletsShot = currState.getBulletsShot() - prevState.getBulletsShot();
+        this.roundShipsDestroyed = currState.getShipsDestroyed() - prevState.getShipsDestroyed();
+        this.roundHitRate = roundShipsDestroyed / (float) roundBulletsShot;
+        this.roundTime = currState.getTime() - prevState.getTime();
+    }
+
+    public int getRoundScore() {
+        return roundScore;
+    }
+
+    public float getRoundHitRate() {
+        return roundHitRate;
+    }
+
+    public long getRoundTime() {
+        return roundTime;
+    }
+
+}

--- a/src/CtrlS/RoundState.java
+++ b/src/CtrlS/RoundState.java
@@ -24,7 +24,7 @@ public class RoundState {
         this.roundCurrency = calculateCurrency();
     }
 
-    public int calculateCurrency() {
+    private int calculateCurrency() {
 
         int baseCurrency = roundScore / 10;
         int levelBonus = baseCurrency * currState.getLevel();

--- a/src/CtrlS/RoundState.java
+++ b/src/CtrlS/RoundState.java
@@ -9,6 +9,7 @@ public class RoundState {
     private final int roundScore;
     private final int roundBulletsShot;
     private final int roundShipsDestroyed;
+    private final int roundCurrency;
     private final float roundHitRate;
     private final long roundTime;
 
@@ -20,6 +21,7 @@ public class RoundState {
         this.roundShipsDestroyed = currState.getShipsDestroyed() - prevState.getShipsDestroyed();
         this.roundHitRate = roundShipsDestroyed / (float) roundBulletsShot;
         this.roundTime = currState.getTime() - prevState.getTime();
+        this.roundCurrency = calculateCurrency();
     }
 
     public int calculateCurrency() {
@@ -72,4 +74,7 @@ public class RoundState {
         return roundTime;
     }
 
+    public int getRoundCurrency() {
+        return roundCurrency;
+    }
 }

--- a/src/CtrlS/RoundState.java
+++ b/src/CtrlS/RoundState.java
@@ -1,5 +1,6 @@
 package CtrlS;
 
+import engine.Core;
 import engine.GameState;
 
 public class RoundState {
@@ -19,6 +20,44 @@ public class RoundState {
         this.roundShipsDestroyed = currState.getShipsDestroyed() - prevState.getShipsDestroyed();
         this.roundHitRate = roundShipsDestroyed / (float) roundBulletsShot;
         this.roundTime = currState.getTime() - prevState.getTime();
+    }
+
+    public int calculateCurrency() {
+
+        int baseCurrency = roundScore / 10;
+        int levelBonus = baseCurrency * currState.getLevel();
+        int currency = baseCurrency + levelBonus;
+
+        if (roundHitRate > 0.9) {
+            currency += (int) (currency * 0.3); // 30% 보너스 지급
+            Core.getLogger().info("hitRate bonus occurs (30%).");
+        } else if (roundHitRate > 0.8) {
+            currency += (int) (currency * 0.2); // 20% 보너스 지급
+            Core.getLogger().info("hitRate bonus occurs (20%).");
+        }
+
+        // Round clear time in seconds
+        // DEBUGGING NEEDED(playTime)
+        long timeDifferenceInSeconds = (currState.getTime() - prevState.getTime()) / 1000;
+
+        int timeBonus = 0;
+
+        /*
+          clear time   : 0 ~ 50    : +50
+                       : 51 ~ 80   : +30
+                       : 81 ~ 100  : +10
+                       : 101 ~     : 0
+         */
+        if (timeDifferenceInSeconds <= 50) {
+            timeBonus = 50;
+        } else if (timeDifferenceInSeconds <= 80) {
+            timeBonus = 30;
+        } else if (timeDifferenceInSeconds <= 100) {
+            timeBonus = 10;
+        }
+        currency += timeBonus;
+
+        return currency;
     }
 
     public int getRoundScore() {

--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import CtrlS.CurrencyManager;
+import CtrlS.RoundState;
 import Sound_Operator.SoundManager;
 import screen.GameScreen;
 import screen.HighScoreScreen;
@@ -121,6 +122,7 @@ public final class Core {
 		gameSettings.add(SETTINGS_LEVEL_7);
 		
 		GameState gameState;
+		RoundState roundState;
 
 		int returnCode = 1;
 		do {
@@ -143,15 +145,13 @@ public final class Core {
 				sm.playBGM("inGame_bgm");
 
 				do {
-					// Record the start time
-					// Ctrl-S
-					long startTime = System.currentTimeMillis();
-
 					// One extra live every few levels.
 					boolean bonusLife = gameState.getLevel()
 							% EXTRA_LIFE_FRECUENCY == 0
 							&& gameState.getLivesRemaining() < MAX_LIVES;
-					
+
+					GameState prevState = gameState;
+
 					currentScreen = new GameScreen(gameState,
 							gameSettings.get(gameState.getLevel() - 1),
 							bonusLife, width, height, FPS);
@@ -162,18 +162,20 @@ public final class Core {
 
 					gameState = ((GameScreen) currentScreen).getGameState();
 
+					roundState = new RoundState(prevState, gameState);
+
 					// Add playtime parameter - Soomin Lee / TeamHUD
 					gameState = new GameState(gameState.getLevel() + 1,
 							gameState.getScore(),
 							gameState.getLivesRemaining(),
 							gameState.getBulletsShot(),
 							gameState.getShipsDestroyed(),
-							// Ctrl-S
-							Core.getCurrencyManager().calculateCurrency(gameState.getScore(), gameState.getLevel(),
-								gameState.getShipsDestroyed() / (float) gameState.getBulletsShot(),
-								startTime,
-								System.currentTimeMillis()),
-							gameState.getTime(), gameState.getGem());
+							gameState.getTime(),
+							gameState.getCurrency() + roundState.getRoundCurrency(),
+							gameState.getGem());
+					LOGGER.info("Round Currency: " + roundState.getRoundCurrency());
+					LOGGER.info("Round Hit Rate: " + roundState.getRoundHitRate());
+					LOGGER.info("Round Time: " + roundState.getRoundTime());
 
 				} while (gameState.getLivesRemaining() > 0
 						&& gameState.getLevel() <= NUM_LEVELS);

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -83,8 +83,6 @@ public class GameScreen extends Screen {
 	private boolean levelFinished;
 	/** Checks if a bonus life is received. */
 	private boolean bonusLife;
-	/** Total currency **/
-	private int currency; // Team-Ctrl-S(Currency)
 	/** Shield item */
 	private TemporaryShield shield;
 
@@ -99,8 +97,10 @@ public class GameScreen extends Screen {
 	// Sound Operator
 	private static SoundManager sm;
 
-	/** Total gem **/
 	// Team-Ctrl-S(Currency)
+	/** Total currency **/
+	private int currency;
+	/** Total gem **/
 	private int gem;
 
 	/**
@@ -134,6 +134,7 @@ public class GameScreen extends Screen {
 		this.bulletsShot = gameState.getBulletsShot();
 		this.shipsDestroyed = gameState.getShipsDestroyed();
 		this.shield = new TemporaryShield();
+		this.currency = gameState.getCurrency(); // Team-Ctrl-S(Currency)
 		this.gem = gameState.getGem(); // Team-Ctrl-S(Currency)
 	}
 


### PR DESCRIPTION
### 주요 변경 사항

#### 1. `RoundState` 클래스 추가
- **역할:** 라운드 시작 전과 종료 후의 `GameState`를 입력받아 해당 라운드의 정보를 저장.
  - 이번 라운드에서 얻은 점수
  - 이번 라운드의 명중률
  - 이번 라운드에서 얻은 화폐
- **`GameState`와의 차이점:** 
  - `GameState`: 게임 전체의 정보를 저장 (총 점수, 총 명중률, 총 부순 함선 수, 총 화폐 획득량 등)
  - `RoundState`: 한 라운드의 정보만 저장.
- **사용:** 라운드 정산 화면에서 `RoundState`를 전달받아 정보 표시를 간편하게 처리.

#### 2. `calculateCurrency`의 이동
- **이전 문제:** 기존의 `calculateCurrency`는 라운드 단위의 계산이었지만, `CurrencyManager`에 존재할 경우 `RoundState` 인자를 불필요하게 넘겨받아야 함.
- **해결:** 한 라운드에서 얻은 화폐를 저장하는 목적에 맞게 `RoundState`의 private 메서드로 이동.

#### 3. `Core` 수정 사항
- **시간 계산:** `gameState.getPlayTime()`을 사용해 시간 계산 (startTime 변수 삭제).
- **`RoundState` 변수 추가:** `prevState`와 `gameState`를 받아 라운드의 상태를 추적.
- **`gameState` 업데이트:** currency는 기존 currency + `roundCurrency`로 업데이트.

### 개선 가능한 부분

#### 1. 화폐 저장 시점
- 현재 시스템은 라운드 단위로 화폐를 계산하고 누적하는 방식.
- 향후 화폐를 라운드 단위로 저장하는 기능을 추가할 수 있음.