### PR TITLE
BugFix / add the condition to check Bullet's ID

### DIFF
--- a/src/entity/Bullet.java
+++ b/src/entity/Bullet.java
@@ -25,7 +25,11 @@ public class Bullet extends Entity {
 	 * if hit occur then checkCount will be false
 	 */
 	protected boolean checkCount;
-
+	//Ctrl S
+	/**
+	 * give unique id for certain shot of bullets
+	 */
+	protected int fire_id;
 	/**
 	 * Constructor, establishes the bullet's properties.
 	 * 
@@ -39,7 +43,9 @@ public class Bullet extends Entity {
 	 */
 	public Bullet(final int positionX, final int positionY, final int speed) {
 		super(positionX, positionY, 3 * 2, 5 * 2, Color.WHITE);
+		//CtrlS
 		this.checkCount = true;
+		//CtrlS
 		this.speed = speed;
 		setSprite();
 	}
@@ -100,4 +106,18 @@ public class Bullet extends Entity {
 	 * 	          New checkCount of the bullet.
 	 */
 	public final void setCheckCount(final boolean checkCount) { this.checkCount = checkCount; }
+
+	/**
+	 * Getter for the fire_id of the bullet
+	 *
+	 * @return Get fire_id of the bullet.
+	 */
+	public final int getFire_id() { return this.fire_id; }
+	/**
+	 * Setter for the fire_id of the bullet.
+	 *
+	 *  @param id
+	 * 	          New fire_id of the bullet.
+	 */
+	public final void setFire_id(final int id) { this.fire_id = id; }
 }


### PR DESCRIPTION
Author : seoyoung Lee
Date : 2024/10/10

Content :
Check fire_id to think group of bullets to one bullet. If ship shot, then fire_id will be granted on that. If the bullet has the ID counted, then another bullet that has same ID does not count.

Bullet.java
- add new variable : fire_id
- add new method : getFire_id(), setFire_id()

GameScreen.java
- add new variable : fire_id, processedFireBullet fire_id : variable to grant our bullets ID
processedFireBullet : Set to save ID that already processed.
- add new fomula : fire_id++; When ship shot, fire_id will be increased
- add new fomula : bullet.setFire_id(fire_id); To grant fire_id to bullet we shoot
- add new condition : !processedFireBullet.contain(bullet.getFire_id)

	modified:   src/entity/Bullet.java
	modified:   src/screen/GameScreen.java

버그 재발생 한 부분 확인해서 수정하였습니다. 

## 문제 인식
 총알이 한 번에 여러 개가 발사되는 기능이 추가되면서 쏜 횟수 한 번에 총알 2개에 각각 hitcount가 오르며 정확도가 1이 넘는 문제를 확인하였습니다.

## 해결 방법  
1. 총알을 쏠 때마다 쏴진 총알들에 fire_id를 부여했습니다. 같이 발사 된 총알이 3개 있으면 해당 총알 3개는 모두 같은 fire_id를 갖습니다. 
2. hitcount가 오르기 전에 해당 fire_id를 가진 총알에 의해 카운트가 되었는지 체크 후에 count합니다.
3. count 된 총알들은 processedFireBullet 집합에 해당 ID를 추가하여 다음번에 같은 총알이 적을 맞춰도 count 되지 않도록 합니다.