### PR TITLE
feat: Add game clear reward gem

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -545,7 +545,7 @@ public class DrawManager {
 	}
 
 	/**
-	 * Draws basic content of game clear screen.
+	 * Draws basic content of game end screen.
 	 *
 	 * @param screen
 	 *            Screen to draw on.
@@ -555,46 +555,16 @@ public class DrawManager {
 	 *            If the score is a new high score.
 	 */
 	// CtrlS
-	public void drawGameClear(final Screen screen, final boolean acceptsInput,
-							 final boolean isNewRecord) {
-		String gameClearString = "Game Clear";
+	public void drawGameEnd(final Screen screen, final boolean acceptsInput,
+							 final boolean isNewRecord, boolean isGameClear) {
+		String gameEndString = isGameClear ? "Game Clear" : "Game Over";
 		String continueOrExitString =
 				"Press Space to play again, Escape to exit";
 
 		int height = isNewRecord ? 4 : 2;
 
 		backBufferGraphics.setColor(Color.GREEN);
-		drawCenteredBigString(screen, gameClearString, screen.getHeight()
-				/ height - fontBigMetrics.getHeight() * 2);
-
-		if (acceptsInput)
-			backBufferGraphics.setColor(Color.GREEN);
-		else
-			backBufferGraphics.setColor(Color.GRAY);
-		drawCenteredRegularString(screen, continueOrExitString,
-				screen.getHeight() / 2 + fontRegularMetrics.getHeight() * 10);
-	}
-
-	/**
-	 * Draws basic content of game over screen.
-	 *
-	 * @param screen
-	 *            Screen to draw on.
-	 * @param acceptsInput
-	 *            If the screen accepts input.
-	 * @param isNewRecord
-	 *            If the score is a new high score.
-	 */
-	public void drawGameOver(final Screen screen, final boolean acceptsInput,
-							 final boolean isNewRecord) {
-		String gameOverString = "Game Over";
-		String continueOrExitString =
-				"Press Space to play again, Escape to exit";
-
-		int height = isNewRecord ? 4 : 2;
-
-		backBufferGraphics.setColor(Color.GREEN);
-		drawCenteredBigString(screen, gameOverString, screen.getHeight()
+		drawCenteredBigString(screen, gameEndString, screen.getHeight()
 				/ height - fontBigMetrics.getHeight() * 2);
 
 		if (acceptsInput)

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -545,6 +545,37 @@ public class DrawManager {
 	}
 
 	/**
+	 * Draws basic content of game clear screen.
+	 *
+	 * @param screen
+	 *            Screen to draw on.
+	 * @param acceptsInput
+	 *            If the screen accepts input.
+	 * @param isNewRecord
+	 *            If the score is a new high score.
+	 */
+	// CtrlS
+	public void drawGameClear(final Screen screen, final boolean acceptsInput,
+							 final boolean isNewRecord) {
+		String gameClearString = "Game Clear";
+		String continueOrExitString =
+				"Press Space to play again, Escape to exit";
+
+		int height = isNewRecord ? 4 : 2;
+
+		backBufferGraphics.setColor(Color.GREEN);
+		drawCenteredBigString(screen, gameClearString, screen.getHeight()
+				/ height - fontBigMetrics.getHeight() * 2);
+
+		if (acceptsInput)
+			backBufferGraphics.setColor(Color.GREEN);
+		else
+			backBufferGraphics.setColor(Color.GRAY);
+		drawCenteredRegularString(screen, continueOrExitString,
+				screen.getHeight() / 2 + fontRegularMetrics.getHeight() * 10);
+	}
+
+	/**
 	 * Draws basic content of game over screen.
 	 *
 	 * @param screen

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -66,6 +66,8 @@ public class ScoreScreen extends Screen {
 
 	private GameState gameState; // Team-Ctrl-S(Currency)
 
+	private boolean isGameClear; // CtrlS
+
 	/**
 	 * Constructor, establishes the properties of the screen.
 	 * 
@@ -95,6 +97,7 @@ public class ScoreScreen extends Screen {
 		this.gameState = gameState; // Team-Ctrl-S(Currency)
 		this.level = gameState.getLevel(); //Team Clove
 		this.statistics = new Statistics(); //Team Clove
+		this.isGameClear = this.livesRemaining > 0 && this.level > 7; // CtrlS
 
 		try {
 			this.highScores = Core.getFileManager().loadHighScores();
@@ -139,7 +142,7 @@ public class ScoreScreen extends Screen {
 				if (this.isNewRecord) {
 					saveScore();
 				}
-				if (this.livesRemaining > 0 && this.level > 7) {
+				if (this.isGameClear) {
 					saveGem();
 				} // CtrlS
 				saveCoin(); // Team-Ctrl-S(Currency)
@@ -152,7 +155,7 @@ public class ScoreScreen extends Screen {
 				if (this.isNewRecord) {
 					saveScore();
 				}
-				if (this.livesRemaining > 0 && this.level > 7) {
+				if (this.isGameClear) {
 					saveGem();
 				} // CtrlS
 				saveCoin(); // Team-Ctrl-S(Currency)
@@ -265,13 +268,8 @@ public class ScoreScreen extends Screen {
 	private void draw() {
 		drawManager.initDrawing(this);
 
-		if (this.livesRemaining > 0 && this.level > 7) {
-			drawManager.drawGameClear(this, this.inputDelay.checkFinished(),
-					this.isNewRecord);
-		} else {
-			drawManager.drawGameOver(this, this.inputDelay.checkFinished(),
-					this.isNewRecord);
-		} // CtrlS
+		drawManager.drawGameEnd(this, this.inputDelay.checkFinished(),
+				this.isNewRecord, this.isGameClear); // CtrlS
 		drawManager.drawResults(this, this.score, this.livesRemaining,
 				this.shipsDestroyed, (float) this.gameState.getHitCount()
 						/ this.bulletsShot, this.isNewRecord, this.gameState);

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -265,8 +265,13 @@ public class ScoreScreen extends Screen {
 	private void draw() {
 		drawManager.initDrawing(this);
 
-		drawManager.drawGameOver(this, this.inputDelay.checkFinished(),
-				this.isNewRecord);
+		if (this.livesRemaining > 0 && this.level > 7) {
+			drawManager.drawGameClear(this, this.inputDelay.checkFinished(),
+					this.isNewRecord);
+		} else {
+			drawManager.drawGameOver(this, this.inputDelay.checkFinished(),
+					this.isNewRecord);
+		} // CtrlS
 		drawManager.drawResults(this, this.score, this.livesRemaining,
 				this.shipsDestroyed, (float) this.gameState.getHitCount()
 						/ this.bulletsShot, this.isNewRecord, this.gameState);

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -241,6 +241,19 @@ public class ScoreScreen extends Screen {
     }
 
 	/**
+	 * Saves the gem into currency file
+	 */
+	// CtrlS
+	private void saveGem() {
+		try {
+			Core.getCurrencyManager().addGem(1);
+			logger.info("You eared 1 Gem for Game Clear");
+		} catch (IOException e) {
+			logger.warning("Couldn't load gem!");
+		}
+	}
+
+	/**
 	 * Draws the elements associated with the screen.
 	 */
 	private void draw() {

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -139,6 +139,9 @@ public class ScoreScreen extends Screen {
 				if (this.isNewRecord) {
 					saveScore();
 				}
+				if (this.livesRemaining > 0 && this.level > 7) {
+					saveGem();
+				} // CtrlS
 				saveCoin(); // Team-Ctrl-S(Currency)
 				saveStatistics(); //Team Clove
 				saveRecentScore(); // Team Clove
@@ -149,6 +152,9 @@ public class ScoreScreen extends Screen {
 				if (this.isNewRecord) {
 					saveScore();
 				}
+				if (this.livesRemaining > 0 && this.level > 7) {
+					saveGem();
+				} // CtrlS
 				saveCoin(); // Team-Ctrl-S(Currency)
 				saveStatistics(); //Team Clove
 				saveRecentScore(); // Team Clove

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -243,7 +243,7 @@ public class ScoreScreen extends Screen {
 	private void saveCoin() {
 		try {
 			Core.getCurrencyManager().addCoin(coin);
-			logger.info("You eared $" + coin);
+			logger.info("You earned $" + coin);
 		} catch (IOException e) {
 			logger.warning("Couldn't load coin!");
         }
@@ -256,7 +256,7 @@ public class ScoreScreen extends Screen {
 	private void saveGem() {
 		try {
 			Core.getCurrencyManager().addGem(1);
-			logger.info("You eared 1 Gem for Game Clear");
+			logger.info("You earned 1 Gem for Game Clear");
 		} catch (IOException e) {
 			logger.warning("Couldn't load gem!");
 		}


### PR DESCRIPTION
## Add function to give 1 gem when player clears game
1 gem is given every time each game is cleared. ('Clear' means when you complete without dying at the last level)

## Changes
`ScoreScreen.java`
   - Add `saveGem()` for increasing 1 gem
   - Add conditions to draw game clear screen and load `saveGem()` only when game is cleared

`DrawManager.java`
   - Add `drawGameClear()` to draw game clear screen

![clear screen (소형)](https://github.com/user-attachments/assets/31858e40-c15a-419c-9284-57369cd8e319)
![log](https://github.com/user-attachments/assets/1afc3633-5c2f-482b-9279-37546cfa6ff0)
![clear gem (소형)](https://github.com/user-attachments/assets/d48c0d30-18e4-4689-82df-f255c7c416d1)


