### PR TITLE
upgrade_status 파일을 통한 플레이어 stat관리, UpgradeManager 추가

### DIFF
--- a/src/CtrlS/RoundState.java
+++ b/src/CtrlS/RoundState.java
@@ -5,6 +5,8 @@ import engine.GameState;
 // item level Bonus
 import inventory_develop.ShipStatus;
 
+import java.io.IOException;
+
 public class RoundState {
     private final GameState prevState;
     private final GameState currState;
@@ -17,8 +19,7 @@ public class RoundState {
     private final float roundHitRate;
     private final long roundTime;
 
-    private ShipStatus shipStatus;   //inventory team
-    private static double statBonus = 1;
+    private double statBonus;
     private static final int COIN_ITEM_VALUE = 10;
 
     public RoundState(GameState prevState, GameState currState) {
@@ -30,11 +31,15 @@ public class RoundState {
         this.roundHitRate = roundHitCount / (float) roundBulletsShot;
         this.roundTime = currState.getTime() - prevState.getTime();
         this.roundCoinItemsCollected = currState.getCoinItemsCollected() - prevState.getCoinItemsCollected();
-        this.roundCoin = calculateCoin();
 
-        //Coin Bonus increase by Level
-        shipStatus = new ShipStatus();
-        shipStatus.loadStatus();
+        // CtrlS: load stat bonus via UpgradeManager
+        try {
+            this.statBonus = Core.getUpgradeManager().getCoinAcquisitionMultiplier();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        this.roundCoin = calculateCoin();
     }
 
     private int calculateCoin() {
@@ -110,8 +115,4 @@ public class RoundState {
     }
 
     public int getRoundCoinItemsCollected() { return roundCoinItemsCollected; }
-
-    public void statBonusIN(){
-        statBonus += shipStatus.getCoinIn();
-    }
 }

--- a/src/CtrlS/UpgradeManager.java
+++ b/src/CtrlS/UpgradeManager.java
@@ -1,0 +1,168 @@
+package CtrlS;
+
+import engine.Core;
+import engine.FileManager;
+
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public final class UpgradeManager {
+
+    /** Singleton instance of the class. */
+    private static UpgradeManager instance;
+    /** Application logger. */
+    private static Logger logger;
+    private static FileManager fileManager;
+
+    // Upgrade keys
+    private static final String COIN_ACQUISITION_MULTIPLIER = "coin_acquisition_multiplier";
+    private static final String ATTACK_SPEED = "attack_speed";
+    private static final String MOVEMENT_SPEED = "movement_speed";
+    private static final String BULLET_SPEED = "bullet_speed";
+
+    /** Decimal format to ensure values have one decimal place. */
+    private static final DecimalFormat decimalFormat = new DecimalFormat("#.#");
+
+    /**
+     * private constructor.
+     */
+    private UpgradeManager() {
+        fileManager = Core.getFileManager();
+        logger = Core.getLogger();
+    }
+
+    /**
+     * Returns shared instance of UpgradeManager.
+     *
+     * @return Shared instance of UpgradeManager.
+     */
+    public static UpgradeManager getInstance() {
+        if (instance == null)
+            instance = new UpgradeManager();
+        return instance;
+    }
+
+    // Methods for coin acquisition multiplier
+
+    /**
+     * Get the current coin acquisition multiplier value.
+     *
+     * @return The current coin acquisition multiplier.
+     * @throws IOException In case of loading problems.
+     */
+    public double getCoinAcquisitionMultiplier() throws IOException {
+        Properties properties = fileManager.loadUpgradeStatus();
+        return Double.parseDouble(properties.getProperty(COIN_ACQUISITION_MULTIPLIER, "1.0"));
+    }
+
+    /**
+     * Add to the current coin acquisition multiplier.
+     *
+     * @param amount The amount to add.
+     * @throws IOException In case of saving problems.
+     */
+    public void addCoinAcquisitionMultiplier(double amount) throws IOException {
+        double currentValue = getCoinAcquisitionMultiplier();
+        currentValue += amount;
+
+        // Format the value to one decimal place
+        String formattedValue = decimalFormat.format(currentValue);
+
+        Properties properties = fileManager.loadUpgradeStatus();
+        properties.setProperty(COIN_ACQUISITION_MULTIPLIER, formattedValue);
+        fileManager.saveUpgradeStatus(properties);
+    }
+
+    // Methods for attack speed
+
+    /**
+     * Get the current attack speed value.
+     *
+     * @return The current attack speed.
+     * @throws IOException In case of loading problems.
+     */
+    public int getAttackSpeed() throws IOException {
+        Properties properties = fileManager.loadUpgradeStatus();
+        return Integer.parseInt(properties.getProperty(ATTACK_SPEED, "1"));
+    }
+
+    /**
+     * Add to the current attack speed.
+     *
+     * @param amount The amount to add.
+     * @throws IOException In case of saving problems.
+     */
+    public void addAttackSpeed(int amount) throws IOException {
+        int currentValue = getAttackSpeed();
+        currentValue += amount;
+        Properties properties = fileManager.loadUpgradeStatus();
+        properties.setProperty(ATTACK_SPEED, Integer.toString(currentValue));
+        fileManager.saveUpgradeStatus(properties);
+    }
+
+    // Methods for movement speed
+
+    /**
+     * Get the current movement speed value.
+     *
+     * @return The current movement speed.
+     * @throws IOException In case of loading problems.
+     */
+    public int getMovementSpeed() throws IOException {
+        Properties properties = fileManager.loadUpgradeStatus();
+        return Integer.parseInt(properties.getProperty(MOVEMENT_SPEED, "1"));
+    }
+
+    /**
+     * Add to the current movement speed.
+     *
+     * @param amount The amount to add.
+     * @throws IOException In case of saving problems.
+     */
+    public void addMovementSpeed(int amount) throws IOException {
+        int currentValue = getMovementSpeed();
+        currentValue += amount;
+        Properties properties = fileManager.loadUpgradeStatus();
+        properties.setProperty(MOVEMENT_SPEED, Integer.toString(currentValue));
+        fileManager.saveUpgradeStatus(properties);
+    }
+
+    // Methods for bullet speed
+
+    /**
+     * Get the current bullet speed value.
+     *
+     * @return The current bullet speed.
+     * @throws IOException In case of loading problems.
+     */
+    public int getBulletSpeed() throws IOException {
+        Properties properties = fileManager.loadUpgradeStatus();
+        return Integer.parseInt(properties.getProperty(BULLET_SPEED, "1"));
+    }
+
+    /**
+     * Add to the current bullet speed.
+     *
+     * @param amount The amount to add.
+     * @throws IOException In case of saving problems.
+     */
+    public void addBulletSpeed(int amount) throws IOException {
+        int currentValue = getBulletSpeed();
+        currentValue += amount;
+        Properties properties = fileManager.loadUpgradeStatus();
+        properties.setProperty(BULLET_SPEED, Integer.toString(currentValue));
+        fileManager.saveUpgradeStatus(properties);
+    }
+
+    /**
+     * Reset all upgrades to their default values.
+     *
+     * @throws IOException In case of saving problems.
+     */
+    public void resetUpgrades() throws IOException {
+        Properties properties = fileManager.loadDefaultUpgradeStatus();
+        fileManager.saveUpgradeStatus(properties);
+    }
+}

--- a/src/Enemy/PlayerGrowth.java
+++ b/src/Enemy/PlayerGrowth.java
@@ -1,5 +1,8 @@
 package Enemy;
 
+import engine.Core;
+import java.io.IOException;
+
 public class PlayerGrowth {
 
     //Player's base stats
@@ -10,6 +13,15 @@ public class PlayerGrowth {
 
     //Constructor to set initial values
     public PlayerGrowth() {//  Base shooting delay is 750ms
+
+        // CtrlS: set player growth based on upgrade_status.properties
+        try {
+            moveSpeed = Core.getUpgradeManager().getMovementSpeed();
+            bulletSpeed = Core.getUpgradeManager().getBulletSpeed();
+            shootingDelay = Core.getUpgradeManager().getAttackSpeed();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     // Increases health

--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -1,5 +1,6 @@
 package engine;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.ConsoleHandler;
@@ -11,6 +12,7 @@ import java.util.logging.Logger;
 import CtrlS.CurrencyManager;
 import CtrlS.RoundState;
 import CtrlS.ReceiptScreen;
+import CtrlS.UpgradeManager;
 import Sound_Operator.SoundManager;
 import level_design.Background;
 import clove.AchievementConditions;
@@ -110,6 +112,9 @@ public final class Core {
 			System.out.println("AchievementManager initialized!");
 			achievementConditions = new AchievementConditions();
 
+			// CtrlS: Make instance of Upgrade Manager
+			Core.getUpgradeManager();
+
 		} catch (Exception e) {
 			// TODO handle exception
 			e.printStackTrace();
@@ -145,7 +150,7 @@ public final class Core {
 			switch (returnCode) {
 			case 1:
 				// Main menu.
-				currentScreen = new TitleScreen(width, height, FPS);
+                currentScreen = new TitleScreen(width, height, FPS);
 				LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
 						+ " title screen at " + FPS + " fps.");
 				returnCode = frame.setScreen(currentScreen);
@@ -426,5 +431,15 @@ public final class Core {
 	// Team-Ctrl-S(Currency)
 	public static CurrencyManager getCurrencyManager() {
 		return CurrencyManager.getInstance();
+	}
+
+	/**
+	 * Controls access to the currency manager.
+	 *
+	 * @return Application currency manager.
+	 */
+	// Team-Ctrl-S(Currency)
+	public static UpgradeManager getUpgradeManager() {
+		return UpgradeManager.getInstance();
 	}
 }

--- a/src/engine/FileManager.java
+++ b/src/engine/FileManager.java
@@ -797,4 +797,105 @@ public final class FileManager {
 
 		return gem;
 	}
+
+	/**
+	 * Loads upgrade statuses from upgrade_status.properties file.
+	 *
+	 * @return Properties object containing the upgrade statuses.
+	 * @throws IOException In case of loading problems.
+	 */
+	public Properties loadUpgradeStatus() throws IOException {
+		Properties properties = new Properties();
+		InputStream inputStream = null;
+
+		try {
+			String jarPath = FileManager.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+			jarPath = URLDecoder.decode(jarPath, "UTF-8");
+
+			String propertiesPath = new File(jarPath).getParent();
+			propertiesPath += File.separator + "upgrade_status.properties";
+
+			File upgradeFile = new File(propertiesPath);
+
+			if (upgradeFile.exists()) {
+				inputStream = new FileInputStream(upgradeFile);
+				properties.load(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
+			} else {
+				logger.info("upgrade_status.properties not found. Loading default upgrade statuses.");
+				properties = loadDefaultUpgradeStatus();
+			}
+
+		} finally {
+			if (inputStream != null) {
+				inputStream.close();
+			}
+		}
+
+		return properties;
+	}
+
+	/**
+	 * Saves upgrade statuses to upgrade_status.properties file.
+	 *
+	 * @param properties The Properties object containing the upgrade statuses to save.
+	 * @throws IOException In case of saving problems.
+	 */
+	public void saveUpgradeStatus(Properties properties) throws IOException {
+		OutputStream outputStream = null;
+
+		try {
+			String jarPath = FileManager.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+			jarPath = URLDecoder.decode(jarPath, "UTF-8");
+
+			String propertiesPath = new File(jarPath).getParent();
+			propertiesPath += File.separator + "upgrade_status.properties";
+
+			File upgradeFile = new File(propertiesPath);
+
+			if (!upgradeFile.exists()) {
+				upgradeFile.createNewFile();
+			}
+
+			outputStream = new FileOutputStream(upgradeFile);
+			properties.store(new OutputStreamWriter(outputStream, Charset.forName("UTF-8")), "Upgrade Statuses");
+
+			logger.info("Saving upgrade statuses.");
+
+		} finally {
+			if (outputStream != null) {
+				outputStream.close();
+			}
+		}
+	}
+
+	/**
+	 * Loads default upgrade statuses from upgrade_default.properties file.
+	 *
+	 * @return Properties object containing the default upgrade statuses.
+	 * @throws IOException In case of loading problems.
+	 */
+    public Properties loadDefaultUpgradeStatus() throws IOException {
+		Properties defaultProperties = new Properties();
+		InputStream inputStream = null;
+
+		try {
+			inputStream = FileManager.class.getClassLoader().getResourceAsStream("upgrade_default.properties");
+			if (inputStream != null) {
+				defaultProperties.load(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
+				logger.info("Default upgrade statuses loaded from upgrade_default.properties.");
+			} else {
+				logger.warning("upgrade_default.properties not found. Using hardcoded default values.");
+				defaultProperties.setProperty("coin_acquisition_multiplier", "1.0");
+				defaultProperties.setProperty("attack_speed", "750");
+				defaultProperties.setProperty("movement_speed", "2");
+				defaultProperties.setProperty("bullet_speed", "-4");
+			}
+		} finally {
+			if (inputStream != null) {
+				inputStream.close();
+			}
+		}
+
+		return defaultProperties;
+	}
 }

--- a/src/screen/TitleScreen.java
+++ b/src/screen/TitleScreen.java
@@ -178,19 +178,23 @@ public class TitleScreen extends Screen {
 	/**
 	 * Shifts the focus to the next menu item.
 	 */
-	private void testStatUpgrade(){
+	private void testStatUpgrade() throws IOException {
 		// CtrlS: testStatUpgrade should only be called after coins are spent
 		if(this.merchantState == 1) {
-			// this.currentCoin -= 50;
+			Core.getUpgradeManager().addBulletSpeed(-1);
+			Core.getLogger().info("Bullet Speed: " + Core.getUpgradeManager().getBulletSpeed());
 		}
 		else if(this.merchantState == 2) {
-			// this.currentCoin -= 50;
+			Core.getUpgradeManager().addMovementSpeed(1);
+			Core.getLogger().info("Movement Speed: " + Core.getUpgradeManager().getMovementSpeed());
 		}
 		else if(this.merchantState == 3) {
-			// this.currentCoin -= 50;
+			Core.getUpgradeManager().addAttackSpeed(-10);
+			Core.getLogger().info("Attack Speed: " + Core.getUpgradeManager().getAttackSpeed());
 		}
 		else if(this.merchantState == 4) {
-			// this.currentCoin -= 50;
+			Core.getUpgradeManager().addCoinAcquisitionMultiplier(0.1);
+			Core.getLogger().info("Coin Acquisition Multiplier: " + Core.getUpgradeManager().getCoinAcquisitionMultiplier());
 		}
 
 


### PR DESCRIPTION
# 추가

## FileManager.java

upgrade_status.properties 파일을 읽고 쓰는 메소드 추가
- loadUpgradeStatus
- saveUpgradeStatus
- loadDefaultUpgradeStatus


## UpgradeManager

플레이어의 stat을 다루는 클래스 추가
- 코인 증가 계수
- 함선 이동 속도
- 총알 속도
- 총알 발사 속도

## TitleScreen

Merchant 기능 구현
- 업그레이드시 실제 반영되도록 구현

#수정

## PlayerGrowth

Ship 객채의 기본 정보인 PlayerGrowth를 upgrade_status.properties의 내용으로 초기화

## RoundState

stat bonus를 upgrade_status.properties의 내용으로 초기화

# 기타

이번 PR은 Item 팀 및 Main menu 팀과의 협업을 위한 기능 구현에 중점을 두었으니 이점 참고 바랍니다.
gem 소비 및 업그레이드 레벨 설정은 협업을 통해 이루어질 예정입니다.