### PR TITLE
중간 정산 화면 출력 방식 변경

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -462,22 +462,20 @@ public class DrawManager {
 	 *            Total ships destroyed.
 	 * @param accuracy
 	 *            Total accuracy.
-	 * @param isNewRecord
-	 *            If the score is a new high score.
 	 */
 
 	//Ctrl S - add Coin String
 	public void drawResults(final Screen screen, final int score,
 							final int livesRemaining, final int shipsDestroyed,
-							final float accuracy, final boolean isNewRecord, final GameState gameState) {
-		String scoreString = String.format("score %04d", score);
-		String livesRemainingString = "lives remaining " + livesRemaining;
-		String shipsDestroyedString = "enemies destroyed " + shipsDestroyed;
+							final float accuracy, final GameState gameState) {
+		String scoreString = String.format("score: %04d", score);
+		String livesRemainingString = "lives remaining: " + livesRemaining;
+		String shipsDestroyedString = "enemies destroyed: " + shipsDestroyed;
 		String accuracyString = String
-				.format("accuracy %.2f%%", accuracy * 100);
-		String coinString = "Earned  $ " + gameState.getCoin() + "  Coins!";
+				.format("accuracy: %.2f%%", accuracy * 100);
+		String coinString = "Total earned  $ " + gameState.getCoin() + "  Coins!";
 
-		int height = isNewRecord ? 4 : 2;
+		int height = 4;
 
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredRegularString(screen, scoreString, screen.getHeight()
@@ -488,6 +486,10 @@ public class DrawManager {
 		drawCenteredRegularString(screen, shipsDestroyedString,
 				screen.getHeight() / height + fontRegularMetrics.getHeight()
 						* 4);
+		//Change the accuracy String when player does not shoot any bullet
+		if (accuracy != accuracy) {
+			accuracyString = "You didn't shoot any bullet.";
+		}
 		drawCenteredRegularString(screen, accuracyString, screen.getHeight()
 				/ height + fontRegularMetrics.getHeight() * 6);
 		drawCenteredRegularString(screen, coinString, screen.getHeight()
@@ -551,21 +553,24 @@ public class DrawManager {
 	 *            Screen to draw on.
 	 * @param acceptsInput
 	 *            If the screen accepts input.
-	 * @param isNewRecord
-	 *            If the score is a new high score.
 	 */
 	// CtrlS
-	public void drawGameEnd(final Screen screen, final boolean acceptsInput,
-							 final boolean isNewRecord, boolean isGameClear) {
+	public void drawGameEnd(final Screen screen, final boolean acceptsInput, boolean isGameClear) {
 		String gameEndString = isGameClear ? "Game Clear" : "Game Over";
 		String continueOrExitString =
 				"Press Space to play again, Escape to exit";
+		String lostBonus = "You lost your Bonus on this level. Try Harder!";
 
-		int height = isNewRecord ? 4 : 2;
+		int height = 4;
 
 		backBufferGraphics.setColor(Color.GREEN);
 		drawCenteredBigString(screen, gameEndString, screen.getHeight()
 				/ height - fontBigMetrics.getHeight() * 2);
+		if (!isGameClear) {
+			backBufferGraphics.setColor(Color.GRAY);
+			drawCenteredRegularString(screen, lostBonus, screen.getHeight()
+					/ height - fontRegularMetrics.getHeight() - 20);
+		}
 
 		if (acceptsInput)
 			backBufferGraphics.setColor(Color.GREEN);
@@ -782,8 +787,9 @@ public class DrawManager {
 		String totalScoreString = "Total Score : ";
 		String stageCoinString = "Coins Obtained";
 		String instructionsString = "Press Space to Continue to get more coin!";
-		String hitrateBonusString = "Hitrate Bonus!! : +30%";
-		String timeBonusString = "Time Bonus!!";
+		String hitrateBonusString = "HitRate Bonus: $ " + roundState.getAccuracyBonus_amount() + "  Coins";
+		String timeBonusString = "Time Bonus: $ " + roundState.getTimeBonus_amount() + "  Coins";
+		String levelBonusString = "Level Bonus: $ " + roundState.getLevelBonus_amount() + "  Coins";
 		//draw Score part
 		backBufferGraphics.setColor(Color.GREEN);
 		drawCenteredBigString(screen, stageScoreString, screen.getHeight() / 8);
@@ -792,47 +798,36 @@ public class DrawManager {
 		backBufferGraphics.setColor(Color.WHITE);
 		drawCenteredRegularString(screen, totalScoreString + gameState.getScore(), screen.getHeight() / 8 + fontRegularMetrics.getHeight() / 2 * 7);
 		//draw Coin part
-		backBufferGraphics.setColor(Color.GREEN);
-		drawCenteredBigString(screen, stageCoinString, screen.getHeight() / 3);
+		backBufferGraphics.setColor(Color.LIGHT_GRAY);
+		drawCenteredBigString(screen, stageCoinString, screen.getHeight() / 3 - 30);
 		backBufferGraphics.setColor(Color.WHITE);
-		drawCenteredBigString(screen, Integer.toString(roundState.getRoundCoin()), screen.getHeight() / 3 + fontBigMetrics.getHeight() / 2 * 3);
+		drawCenteredBigString(screen, Integer.toString(roundState.getBaseCoin_amount()), (screen.getHeight() / 3) - 30 + fontBigMetrics.getHeight() / 2 * 3);
 
 		//draw HitRate Bonus part
-		float hitRate = roundState.getRoundHitRate(); // Calculate HitRate
-		if (hitRate > 0.9) {
+		if (roundState.getAccuracyBonus_amount() != 0) {
 			backBufferGraphics.setColor(Color.LIGHT_GRAY);
-			drawCenteredRegularString(screen, hitrateBonusString, screen.getHeight() / 3 + fontRegularMetrics.getHeight() / 2 * 7);
-		}
-		else if (hitRate > 0.8) {
-			hitrateBonusString = "Hitrate Bonus!! : +20%";
-			backBufferGraphics.setColor(Color.LIGHT_GRAY);
-			drawCenteredRegularString(screen, hitrateBonusString, screen.getHeight() / 3 + fontRegularMetrics.getHeight() / 2 * 7);
+			backBufferGraphics.setFont(fontRegular);
+			backBufferGraphics.drawString(hitrateBonusString, screen.getWidth() / 2 - fontRegularMetrics.stringWidth(hitrateBonusString) / 2, (screen.getHeight() / 3) - 30 + fontRegularMetrics.getHeight() / 2 * 7);
 		}
 		//draw Time Bonus part
-		long time = roundState.getRoundTime();
-		int num = (time <= 50) ? 0 : (time <= 80) ? 1 : (time <= 100) ? 2 : 3;
-		switch (num) {
-			case 0:
-				timeBonusString = "Time Bonus!! : +50";
-				backBufferGraphics.setColor(Color.LIGHT_GRAY);
-				drawCenteredRegularString(screen, timeBonusString, screen.getHeight() / 3 + fontRegularMetrics.getHeight() / 2 * 9);
-				break;
-			case 1:
-				timeBonusString = "Time Bonus!! : +30";
-				backBufferGraphics.setColor(Color.LIGHT_GRAY);
-				drawCenteredRegularString(screen, timeBonusString, screen.getHeight() / 3 + fontRegularMetrics.getHeight() / 2 * 9);
-				break;
-			case 2:
-				timeBonusString = "Time Bonus!! : +10";
-				backBufferGraphics.setColor(Color.LIGHT_GRAY);
-				drawCenteredRegularString(screen, timeBonusString, screen.getHeight() / 3 + fontRegularMetrics.getHeight() / 2 * 9);
-				break;
-			case 3:
-				timeBonusString = "You missed TimeBonus! Try harder!";
-				backBufferGraphics.setColor(Color.LIGHT_GRAY);
-				drawCenteredRegularString(screen, timeBonusString, screen.getHeight() / 3 + fontRegularMetrics.getHeight() / 2 * 9);
+		if (roundState.getTimeBonus_amount() != 0) {
+			backBufferGraphics.setColor(Color.LIGHT_GRAY);
+			backBufferGraphics.setFont(fontRegular);
+			backBufferGraphics.drawString(timeBonusString, screen.getWidth() / 2 - fontRegularMetrics.stringWidth(timeBonusString) / 2, (screen.getHeight() / 3) - 30 + fontRegularMetrics.getHeight() / 2 * 9);
 		}
+		//draw level Bonus part
+		if (roundState.getLevelBonus_amount() != 0) {
+			backBufferGraphics.setColor(Color.LIGHT_GRAY);
+			backBufferGraphics.setFont(fontRegular);
+			backBufferGraphics.drawString(levelBonusString, screen.getWidth() / 2 - fontRegularMetrics.stringWidth(levelBonusString) / 2, (screen.getHeight() / 3) - 30 + fontRegularMetrics.getHeight() / 2 * 11);
+		}
+		//draw Total coins part
+		backBufferGraphics.setColor(Color.GREEN);
+		drawCenteredBigString(screen, "Total Round Coins", screen.getHeight() / 3 + 120);
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredBigString(screen, Integer.toString(roundState.getRoundCoin()), screen.getHeight() / 3 + 120 + fontBigMetrics.getHeight() / 2 * 3);
 
+		//draw instructionString part
 		backBufferGraphics.setColor(Color.GRAY);
 		drawCenteredRegularString(screen, instructionsString,
 				screen.getHeight() / 2 + fontRegularMetrics.getHeight() * 10);

--- a/src/screen/ScoreScreen.java
+++ b/src/screen/ScoreScreen.java
@@ -268,11 +268,10 @@ public class ScoreScreen extends Screen {
 	private void draw() {
 		drawManager.initDrawing(this);
 
-		drawManager.drawGameEnd(this, this.inputDelay.checkFinished(),
-				this.isNewRecord, this.isGameClear); // CtrlS
+		drawManager.drawGameEnd(this, this.inputDelay.checkFinished(), this.isGameClear); // CtrlS
 		drawManager.drawResults(this, this.score, this.livesRemaining,
 				this.shipsDestroyed, (float) this.gameState.getHitCount()
-						/ this.bulletsShot, this.isNewRecord, this.gameState);
+						/ this.bulletsShot, this.gameState);
 
 		if (this.isNewRecord)
 			drawManager.drawNameInput(this, this.name, this.nameCharSelected);


### PR DESCRIPTION
## 변경 내용 
### DrawManger.java
RoundState에서 해당 값들을 가져와 drawReiceiptScreen 메소드에 각 보너스들을 출력하도록 바꾸었고, 추가적으로 기본적으로 위해 Base coin 을 출력하고 밑에 보너스들을 출력, 그리고 그 밑에 최종적으로 이번 라운드에 얻은 코인을 표시하도록 바꾸었습니다.

추가적으로, ScoreScreen의 경우에는 보너스마다 얻은 코인까지 넣어버리면 너무 복잡해지고 글이 많아져서 오히려 역효과가 날 것 같아서 GameOver인 경우에는 GameOver 메세지 밑에 이번 라운드에 얻은 보너스를 잃었다는 메세지를 출력하도록 변경하였습니다. 

추가적인 사소한 버그사항으로 총을 한 번도 쏘지 않고 게임이 종료될 경우에 accuracy가 0/0가 되어 NaN % 출력되는 경우에 대해서 특정 메세지를 출력하도록 변경하였습니다. 
### ScoreScreen.java
신기록인지 여부에 따라 Height를 4 혹은 2로 결정하는 것이 있었는데, 이 경우 신기록이 아닐경우에 위의 GameClear가 화면 중간부분으로 내려가는데, 개인적으로 이것보다는 그냥 같은 위치에 표시되는 것이 덜 복잡해보이고 깔끔해보여서 삭제하였습니다. 
### RoundState.java
기존의 calculateCoin 메소드를 베이스코인과 각 보너스 부분으로 쪼갰습니다. 그리고 해당 roundState 객체에 private final 변수로 보너스와 베이스 코인 변수를 생성하여 객체 생성자 호출 시 각 값을 계산하는 메소드에 의해 초기화 시키고 이를 DrawManger에서 이용할 수 있게 getter를 정의하였습니다.

## 스크린샷
![{03C7F53D-7622-4589-8856-334F76DD76DB}](https://github.com/user-attachments/assets/76735fce-9c5d-4bb4-839c-b2065fc9b783)
보너스 기준에 미치지 못해 지급되지 않을 경우에는 메세지가 출력되지 않습니다. 

![{4EDC492F-18E2-498B-8FE2-ADD8417AB102}](https://github.com/user-attachments/assets/e27abc61-a240-4838-9469-6f47ed1b5cbe)
GameOver시에 밑에 메세지가 출력됩니다. 

![{0B9B4918-2633-41C7-BBD7-D2A0C5EA2F4E}](https://github.com/user-attachments/assets/24eaee92-d2d8-4676-9bcf-09dca7320285)
총을 아예 쏘지 않고 게임이 마무리 된 경우, 총을 쏘지 않았다는 메세지를 대신 출력합니다. 

![{4E0D520C-89AE-4853-A69B-78B0484E4A81}](https://github.com/user-attachments/assets/381abdc0-cdfc-4aaa-a0fc-0f54b6f0b4c4)
위에서 볼 수 있듯이 이제 신기록이든 아니든 간에 관계 없이 위치가 동일합니다.